### PR TITLE
PI-3673 Increase alert period for yellow cluster status in dev

### DIFF
--- a/projects/api/helm_deploy/values-dev.yaml
+++ b/projects/api/helm_deploy/values-dev.yaml
@@ -20,3 +20,4 @@ generic-prometheus-alerts:
   openSearchAlertsDomainNames:
     cloud-platform-7ee2c0ee: OpenSearch
   openSearchAlertsFreeStorageSpaceThresholdGB: 7.5
+  openSearchAlertsClusterStatusYellowMinutes: 30 # cluster status can be yellow during replication following data re-indexing - this is expected


### PR DESCRIPTION
Otherwise, the alert fires every Monday morning while data is being replicated following the contact reindexing job.

See https://mojdt.slack.com/archives/C033HPR0W91/p1765186494849019